### PR TITLE
Fix compilation errors for libdns v1.0.0

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/libdns/libdns"
@@ -24,8 +25,8 @@ func main() {
 
 	// Append Records Test
 	recordsAdded, err := provider.AppendRecords(ctx, zone, []libdns.Record{
-		{Type: "A", Name: "test1", Value: "8.8.4.4", TTL: time.Duration(123) * time.Second},
-		{Type: "CNAME", Name: "test2", Value: "www.example.com.", TTL: time.Duration(666) * time.Second},
+		libdns.Address{Name: "test1", IP: netip.MustParseAddr("8.8.4.4"), TTL: time.Duration(123) * time.Second},
+		libdns.CNAME{Name: "test2", Target: "www.example.com.", TTL: time.Duration(666) * time.Second},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
@@ -33,9 +34,9 @@ func main() {
 
 	// Set Records Test
 	recordsSet, err := provider.SetRecords(ctx, zone, []libdns.Record{
-		{Type: "A", Name: "test1", Value: "8.8.8.8", TTL: time.Duration(999) * time.Second},
-		{Type: "CNAME", Name: "test2", Value: "test2.example.com", TTL: time.Duration(999) * time.Second},
-		{Type: "CNAME", Name: "test3", Value: "test3.example.net"},
+		libdns.Address{Name: "test1", IP: netip.MustParseAddr("8.8.8.8"), TTL: time.Duration(999) * time.Second},
+		libdns.CNAME{Name: "test2", Target: "test2.example.com", TTL: time.Duration(999) * time.Second},
+		libdns.CNAME{Name: "test3", Target: "test3.example.net"},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
@@ -43,8 +44,8 @@ func main() {
 
 	// Delete Records Test
 	recordsDeleted, err := provider.DeleteRecords(ctx, zone, []libdns.Record{
-		{Type: "A", Name: "test1"},
-		{Type: "CNAME", Name: "test2"},
+		libdns.Address{Name: "test1"},
+		libdns.CNAME{Name: "test2"},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/client.go
+++ b/client.go
@@ -93,8 +93,9 @@ func (p *Provider) addRecord(ctx context.Context, zone string, record libdns.Rec
 
 	var addedRecords []libdns.Record
 
+	rr := record.RR()
 	data := mythicRecords{}
-	data.Records = append(data.Records, mythicRecord{Type: record.Type, Name: record.Name, Value: record.Value, TTL: int(record.TTL.Seconds())})
+	data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
 
 	payload, err := json.Marshal(data)
 	if err != nil {
@@ -156,8 +157,9 @@ func (p *Provider) updateRecord(ctx context.Context, zone string, record libdns.
 
 	var updatedRecords []libdns.Record
 
+	rr := record.RR()
 	data := mythicRecords{}
-	data.Records = append(data.Records, mythicRecord{Type: record.Type, Name: record.Name, Value: record.Value, TTL: int(record.TTL.Seconds())})
+	data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
 
 	payload, err := json.Marshal(data)
 
@@ -171,8 +173,8 @@ func (p *Provider) updateRecord(ctx context.Context, zone string, record libdns.
 		"/zones/"+
 		zone+
 		"/records/"+
-		record.Name+"/"+
-		record.Type+
+		rr.Name+"/"+
+		rr.Type+
 		"?exclude-template&exclude-generated", body)
 	if err != nil {
 		return nil, fmt.Errorf("addRecord: Error in NewRequestWithContext: %s", err.Error())
@@ -228,8 +230,9 @@ func (p *Provider) removeRecord(ctx context.Context, zone string, record libdns.
 
 	var removedRecords []libdns.Record
 
+	rr := record.RR()
 	data := mythicRecords{}
-	data.Records = append(data.Records, mythicRecord{Type: record.Type, Name: record.Name, Value: record.Value, TTL: int(record.TTL.Seconds())})
+	data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
 
 	payload, err := json.Marshal(data)
 	if err != nil {
@@ -241,8 +244,8 @@ func (p *Provider) removeRecord(ctx context.Context, zone string, record libdns.
 		"/zones/"+
 		zone+
 		"/records/"+
-		record.Name+"/"+
-		record.Type+
+		rr.Name+"/"+
+		rr.Type+
 		"?exclude-template&exclude-generated", body)
 	if err != nil {
 		return nil, fmt.Errorf("addRecord: Error in NewRequestWithContext: %s", err.Error())

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/libdns/mythicbeasts
 go 1.16
 
 require (
-	github.com/libdns/libdns v0.2.1
+	github.com/libdns/libdns v1.0.0
 	golang.org/x/net v0.0.0-20220531201128-c960675eff93
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/libdns/mythicbeasts
 go 1.16
 
 require (
-	github.com/libdns/libdns v1.0.0
+	github.com/libdns/libdns v1.0.0-beta.1
 	golang.org/x/net v0.0.0-20220531201128-c960675eff93
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
-github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0-beta.1 h1:KIf4wLfsrEpXpZ3vmc/poM8zCATXT2klbdPe6hyOBjQ=
+github.com/libdns/libdns v1.0.0-beta.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
+github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/provider.go
+++ b/provider.go
@@ -68,12 +68,17 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	var records []libdns.Record
 
 	for _, r := range result.Records {
-		records = append(records, libdns.RR{
+		record, err := libdns.RR{
 			Type: r.Type,
 			Name: r.Name,
 			Data: r.Value,
 			TTL:  time.Duration(r.TTL) * time.Second,
-		})
+		}.Parse()
+		if err != nil {
+			return nil, fmt.Errorf("GetRecords: failed to parse record %s: %d", r.Name, err)
+		}
+
+		records = append(records, record)
 	}
 	return records, nil
 }

--- a/provider.go
+++ b/provider.go
@@ -68,11 +68,11 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	var records []libdns.Record
 
 	for _, r := range result.Records {
-		records = append(records, libdns.Record{
-			Type:  r.Type,
-			Name:  r.Name,
-			Value: r.Value,
-			TTL:   time.Duration(r.TTL) * time.Second,
+		records = append(records, libdns.RR{
+			Type: r.Type,
+			Name: r.Name,
+			Data: r.Value,
+			TTL:  time.Duration(r.TTL) * time.Second,
 		})
 	}
 	return records, nil


### PR DESCRIPTION
Currently a first pass at fixing the compilation errors for libdns v1.0.0. See #1

Perhaps not the best fix as our GetRecords() always returns libdns.RR types which looks like is not best practice from the libdns docs: https://pkg.go.dev/github.com/libdns/libdns@v1.0.0#pkg-overview

I've confirmed that it compiles and I can use the code in the _example folder to correctly update a zone hosted at Mythic Beasts.

I'll also see if I can improve GetRecords(), but would appreciate any feedback if anybody is watching.

Fixes #1