### PR TITLE
Fix unhandled record types

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -25,8 +25,16 @@ func main() {
 
 	// Append Records Test
 	recordsAdded, err := provider.AppendRecords(ctx, zone, []libdns.Record{
-		libdns.Address{Name: "test1", IP: netip.MustParseAddr("8.8.4.4"), TTL: time.Duration(123) * time.Second},
-		libdns.CNAME{Name: "test2", Target: "www.example.com.", TTL: time.Duration(666) * time.Second},
+		libdns.Address{Name: "appendtest1", IP: netip.MustParseAddr("8.8.4.4"), TTL: time.Duration(123) * time.Second},
+		libdns.Address{Name: "appendtest2", IP: netip.MustParseAddr("2a00:1098:0:80:1000:3b:1:1"), TTL: time.Duration(123) * time.Second},
+		libdns.RR{Name: "appendtest3", Type: "ANAME", Data: "www.google.co.uk.", TTL: time.Duration(999) * time.Second},
+		libdns.CNAME{Name: "appendtest4", Target: "www.example.com.", TTL: time.Duration(666) * time.Second},
+		libdns.RR{Name: "appendtest5", Type: "DNAME", Data: "www.google.co.uk.", TTL: time.Duration(999) * time.Second},
+		libdns.NS{Name: "appendtest6", Target: "ns1.mythic-beasts.com.", TTL: time.Duration(999) * time.Second},
+		libdns.RR{Name: "appendtest7", Type: "PTR", Data: "test.example.com.", TTL: time.Duration(999) * time.Second},
+		libdns.TXT{Name: "appendtest8", Text: "This is a test record", TTL: time.Duration(999) * time.Second},
+		libdns.MX{Name: "appendtest9", Target: "mail.example.com.", Preference: 10, TTL: time.Duration(999) * time.Second},
+		libdns.MX{Name: "appendtest10", Target: "mail2.example.com.", Preference: 20, TTL: time.Duration(999) * time.Second},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/_example/main.go
+++ b/_example/main.go
@@ -38,6 +38,7 @@ func main() {
 		libdns.CAA{Name: "appendtest11", Flags: 128, Tag: "issue", Value: "letsencrypt.org", TTL: time.Duration(999) * time.Second},
 		libdns.SRV{Service: "sip", Transport: "tcp", Name: "appendtest12", Target: "srv.example.com.", Port: 443, Priority: 10, Weight: 5, TTL: time.Duration(999) * time.Second},
 		libdns.RR{Name: "appendtest13", Type: "SSHFP", Data: "3 2 abc1234abc", TTL: time.Duration(999) * time.Second},
+		libdns.RR{Name: "appendtest14", Type: "TLSA", Data: "2 1 2 dab111caba", TTL: time.Duration(999) * time.Second},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/_example/main.go
+++ b/_example/main.go
@@ -35,6 +35,8 @@ func main() {
 		libdns.TXT{Name: "appendtest8", Text: "This is a test record", TTL: time.Duration(999) * time.Second},
 		libdns.MX{Name: "appendtest9", Target: "mail.example.com.", Preference: 10, TTL: time.Duration(999) * time.Second},
 		libdns.MX{Name: "appendtest10", Target: "mail2.example.com.", Preference: 20, TTL: time.Duration(999) * time.Second},
+		libdns.CAA{Name: "appendtest11", Flags: 128, Tag: "issue", Value: "letsencrypt.org", TTL: time.Duration(999) * time.Second},
+		libdns.SRV{Service: "sip", Transport: "tcp", Name: "appendtest12", Target: "srv.example.com.", Port: 443, Priority: 10, Weight: 5, TTL: time.Duration(999) * time.Second},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/_example/main.go
+++ b/_example/main.go
@@ -42,9 +42,11 @@ func main() {
 
 	// Set Records Test
 	recordsSet, err := provider.SetRecords(ctx, zone, []libdns.Record{
-		libdns.Address{Name: "test1", IP: netip.MustParseAddr("8.8.8.8"), TTL: time.Duration(999) * time.Second},
-		libdns.CNAME{Name: "test2", Target: "test2.example.com", TTL: time.Duration(999) * time.Second},
-		libdns.CNAME{Name: "test3", Target: "test3.example.net"},
+		libdns.Address{Name: "settest1", IP: netip.MustParseAddr("8.8.8.8"), TTL: time.Duration(999) * time.Second},
+		libdns.CNAME{Name: "settest2", Target: "test2.example.com", TTL: time.Duration(999) * time.Second},
+		libdns.CNAME{Name: "settest3", Target: "test3.example.net"},
+		libdns.MX{Name: "settest4", Target: "mail3.example.com.", Preference: 5, TTL: time.Duration(999) * time.Second},
+		libdns.MX{Name: "settest5", Target: "mail4.example.com.", Preference: 8, TTL: time.Duration(999) * time.Second},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
@@ -52,8 +54,8 @@ func main() {
 
 	// Delete Records Test
 	recordsDeleted, err := provider.DeleteRecords(ctx, zone, []libdns.Record{
-		libdns.Address{Name: "test1"},
-		libdns.CNAME{Name: "test2"},
+		libdns.Address{Name: "settest1"},
+		libdns.CNAME{Name: "settest2"},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/_example/main.go
+++ b/_example/main.go
@@ -37,6 +37,7 @@ func main() {
 		libdns.MX{Name: "appendtest10", Target: "mail2.example.com.", Preference: 20, TTL: time.Duration(999) * time.Second},
 		libdns.CAA{Name: "appendtest11", Flags: 128, Tag: "issue", Value: "letsencrypt.org", TTL: time.Duration(999) * time.Second},
 		libdns.SRV{Service: "sip", Transport: "tcp", Name: "appendtest12", Target: "srv.example.com.", Port: 443, Priority: 10, Weight: 5, TTL: time.Duration(999) * time.Second},
+		libdns.RR{Name: "appendtest13", Type: "SSHFP", Data: "3 2 abc1234abc", TTL: time.Duration(999) * time.Second},
 	})
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/client.go
+++ b/client.go
@@ -93,9 +93,9 @@ func (p *Provider) addRecord(ctx context.Context, zone string, record libdns.Rec
 
 	var addedRecords []libdns.Record
 
-	rr := record.RR()
+	//rr := record.RR()
 	data := mythicRecords{}
-	data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
+	//data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
 
 	payload, err := json.Marshal(data)
 	if err != nil {
@@ -159,7 +159,7 @@ func (p *Provider) updateRecord(ctx context.Context, zone string, record libdns.
 
 	rr := record.RR()
 	data := mythicRecords{}
-	data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
+	//data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
 
 	payload, err := json.Marshal(data)
 
@@ -232,7 +232,7 @@ func (p *Provider) removeRecord(ctx context.Context, zone string, record libdns.
 
 	rr := record.RR()
 	data := mythicRecords{}
-	data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
+	//data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
 
 	payload, err := json.Marshal(data)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -93,9 +93,11 @@ func (p *Provider) addRecord(ctx context.Context, zone string, record libdns.Rec
 
 	var addedRecords []libdns.Record
 
-	//rr := record.RR()
 	data := mythicRecords{}
-	//data.Records = append(data.Records, mythicRecord{Type: rr.Type, Name: rr.Name, Value: rr.Data, TTL: int(rr.TTL.Seconds())})
+	var err = data.FromLibdns([]libdns.Record{record})
+	if err != nil {
+		return nil, fmt.Errorf("addRecord: Error converting libdns record to mythic record: %s", err.Error())
+	}
 
 	payload, err := json.Marshal(data)
 	if err != nil {
@@ -113,7 +115,7 @@ func (p *Provider) addRecord(ctx context.Context, zone string, record libdns.Rec
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("addRecord: Error creating JSON payload: %s", err.Error())
+		return nil, fmt.Errorf("addRecord: Error making HTTP request: %s", err.Error())
 	}
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()

--- a/mythicbeasts.go
+++ b/mythicbeasts.go
@@ -1,5 +1,14 @@
 package mythicbeasts
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
 type mythicAuthResponse struct {
 	Token     string `json:"access_token,omitempty"` // The bearer token for use in API requests
 	Lifetime  int    `json:"expires_in,omitempty"`   // The maximum lifetime of the token in seconds
@@ -11,6 +20,11 @@ type mythicAuthResponseError struct {
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
+type mythicRecordType interface {
+	GetName() string
+	GetLibdnsRecord() (libdns.Record, error)
+}
+
 type mythicRecord struct {
 	Type  string `json:"type,omitempty"`
 	Name  string `json:"host,omitempty"`
@@ -18,8 +32,80 @@ type mythicRecord struct {
 	TTL   int    `json:"ttl,omitempty"`
 }
 
+func (r mythicRecord) GetName() string {
+	return r.Name
+}
+func (r mythicRecord) GetLibdnsRecord() (libdns.Record, error) {
+	return libdns.RR{
+		Type: r.Type,
+		Name: r.Name,
+		Data: r.Value,
+		TTL:  time.Duration(r.TTL) * time.Second,
+	}.Parse()
+}
+
+type mythicMxRecord struct {
+	mythicRecord
+	Priority uint16 `json:"mx_priority,omitempty"` // The priority of the MX record
+}
+
+func (r mythicMxRecord) GetName() string {
+	return r.Name
+}
+func (r mythicMxRecord) GetLibdnsRecord() (libdns.Record, error) {
+	return libdns.MX{
+		Name:       r.Name,
+		TTL:        time.Duration(r.TTL) * time.Second,
+		Preference: r.Priority,
+		Target:     r.Value,
+	}, nil
+}
+
 type mythicRecords struct {
-	Records []mythicRecord `json:"records,omitempty"`
+	Records []mythicRecordType `json:"records,omitempty"`
+}
+
+func (mrl *mythicRecords) UnmarshalJSON(data []byte) error {
+	var untypedRecords struct {
+		Records []json.RawMessage `json:"records,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &untypedRecords); err != nil {
+		return err
+	}
+
+	mrl.Records = make([]mythicRecordType, len(untypedRecords.Records))
+
+	for r, rawRecord := range untypedRecords.Records {
+		// First unmarshal just to get the type
+		var base mythicRecord
+
+		if err := json.Unmarshal(rawRecord, &base); err != nil {
+			fmt.Errorf("failed to unmarshal base fields for item %d: %w", r, err)
+		}
+
+		switch base.Type {
+		case "A", "AAAA", "ANAME", "CNAME", "DNAME", "NS", "PTR", "TXT":
+			var record mythicRecord
+			if err := json.Unmarshal(rawRecord, &record); err != nil {
+				return fmt.Errorf("failed to unmarshal record of type %s: %v", base.Type, err)
+			}
+			mrl.Records[r] = record
+		case "MX":
+			var mxRecord mythicMxRecord
+			if err := json.Unmarshal(rawRecord, &mxRecord); err != nil {
+				return fmt.Errorf("failed to unmarshal MX record: %v", err)
+			}
+			mrl.Records[r] = mxRecord
+		default:
+			return fmt.Errorf("unknown type: %s", base.Type)
+		}
+	}
+
+	return nil
+}
+func (mrl *mythicRecords) FromLibdns(libdnsrecords []libdns.RR) error {
+	return errors.New("not implemented")
 }
 
 type mythicRecordUpdate struct {

--- a/mythicbeasts.go
+++ b/mythicbeasts.go
@@ -21,6 +21,7 @@ type mythicAuthResponseError struct {
 
 type mythicRecordType interface {
 	GetName() string
+	GetType() string
 	GetLibdnsRecord() (libdns.Record, error)
 }
 
@@ -33,6 +34,9 @@ type mythicRecord struct {
 
 func (r mythicRecord) GetName() string {
 	return r.Name
+}
+func (r mythicRecord) GetType() string {
+	return r.Type
 }
 func (r mythicRecord) GetLibdnsRecord() (libdns.Record, error) {
 	return libdns.RR{
@@ -50,6 +54,9 @@ type mythicMxRecord struct {
 
 func (r mythicMxRecord) GetName() string {
 	return r.Name
+}
+func (r mythicMxRecord) GetType() string {
+	return r.Type
 }
 func (r mythicMxRecord) GetLibdnsRecord() (libdns.Record, error) {
 	return libdns.MX{

--- a/provider.go
+++ b/provider.go
@@ -2,14 +2,12 @@ package mythicbeasts
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/libdns/libdns"
 	"golang.org/x/net/publicsuffix"
@@ -62,20 +60,14 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	}
 
 	result := mythicRecords{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("login: failed to extract JSON data: %d", err)
-	}
+
+	result.UnmarshalJSON(body)
 	var records []libdns.Record
 
 	for _, r := range result.Records {
-		record, err := libdns.RR{
-			Type: r.Type,
-			Name: r.Name,
-			Data: r.Value,
-			TTL:  time.Duration(r.TTL) * time.Second,
-		}.Parse()
+		record, err := r.GetLibdnsRecord()
 		if err != nil {
-			return nil, fmt.Errorf("GetRecords: failed to parse record %s: %d", r.Name, err)
+			return nil, fmt.Errorf("GetRecords: failed to parse record %s: %d", r.GetName(), err)
 		}
 
 		records = append(records, record)

--- a/provider.go
+++ b/provider.go
@@ -61,7 +61,11 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 
 	result := mythicRecords{}
 
-	result.UnmarshalJSON(body)
+	err = result.UnmarshalJSON(body)
+	if err != nil {
+		return nil, fmt.Errorf("GetRecords: failed to unmarshal response: %d", err)
+	}
+
 	var records []libdns.Record
 
 	for _, r := range result.Records {


### PR DESCRIPTION
This is my first attempt at implementing support for the missing DNS record types.

The overall approach is to create new structs for DNS records that have additional properties. The only example of this so far is mythicMxRecord which includes the additional Priority field. This type is then used both when unmarshalling JSON responses from the Mythic Beasts API and also when marshalling requests back to the Mythic Beasts API, to ensure that we can use the additional mx_priority property.

I also looked at libdns/cloudflare as another example and their approach is similar, but they use one big cfDNSRecord struct.

Records such as A, AAAA, CNAME, NS, PTR and TXT don't use any properties other than "Type", "Name", "Data" and "TTL" that all records contain and are in libdns.RR. So they can be parsed by the libdns.RR.Parse() method to return the correct type.

Records such as ANAME and DNAME use the same fields as in libdns.RR, but they are not offical DNS record types as far as I know so libdns.RR.Parse() just leaves them as RR records. I think the correct thing to do would be to return our own types to represent these that implement libdns.Record, but I haven't done this, and it seems less important as they can be handled as RR records.

Records such as CAA and SRV use different properties, so need their own mythicRecord type., which are not implemented yet.

Records such as SSHFP and TLSA are official DNS records, so I think the correct thing to do is for them to be added as upstream types to libdns. Until this is done they would be returned as RR records also, but this is not implemented yet either.

~~Currently this all only works through GetRecords() and AppendRecords().
SetRecords() and DeleteRecords() are broken (lines are commented).~~

I also added more test data to the example application.

As I mentioned before I'm also learning my way through go at the same time as doing this, so any comments are appreciated. I'll be carrying on implementing the remaining parts.

Fixes #3 