### PR TITLE
Refactor DNS record operations to support restricted API keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,98 +144,110 @@ func (p *Provider) doAPIRequest(ctx context.Context, method, url string, body io
 }
 
 func (p *Provider) addRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	type hostType struct {
+		host  string
+		rType string
+	}
+
+	groups := make(map[hostType][]libdns.Record)
+	for _, record := range records {
+		rr := record.RR()
+		host := rr.Name
+		if host == "" {
+			host = "@"
+		}
+		key := hostType{host: host, rType: rr.Type}
+		groups[key] = append(groups[key], record)
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	var addedRecords []libdns.Record
 
-	data := mythicRecords{}
-	var err = data.FromLibdns(records)
-	if err != nil {
-		return nil, fmt.Errorf("addRecords: Error converting libdns record to mythic record: %s", err.Error())
+	for key, groupRecords := range groups {
+		data := mythicRecords{}
+		var err = data.FromLibdns(groupRecords)
+		if err != nil {
+			return nil, fmt.Errorf("addRecords: Error converting libdns record to mythic record: %w", err)
+		}
+
+		payload, err := json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("addRecords: Error creating JSON payload: %w", err)
+		}
+
+		reqURL := apiURL + "/zones/" + url.PathEscape(zone) + "/records/" + url.PathEscape(key.host) + "/" + url.PathEscape(key.rType)
+		respBody, err := p.doAPIRequest(ctx, "POST", reqURL, bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("addRecords: %w", err)
+		}
+
+		appendResp := mythicRecordUpdate{}
+		err = json.Unmarshal(respBody, &appendResp)
+		if err != nil {
+			return nil, fmt.Errorf("addRecords: error parsing response: %w", err)
+		}
+
+		addedRecords = append(addedRecords, groupRecords...)
 	}
 
-	payload, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("addRecords: Error creating JSON payload: %s", err.Error())
-	}
-
-	respBody, err := p.doAPIRequest(ctx, "POST", apiURL+"/zones/"+url.PathEscape(zone)+"/records", bytes.NewReader(payload))
-	if err != nil {
-		return nil, fmt.Errorf("addRecords: %w", err)
-	}
-
-	appendResp := mythicRecordUpdate{}
-	err = json.Unmarshal(respBody, &appendResp)
-	if err != nil {
-		return nil, fmt.Errorf("addRecords: error parsing response: %w", err)
-	}
-
-	// Assuming all were added if successful.
-	addedRecords = append(addedRecords, records...)
 	return addedRecords, nil
 }
 
 func (p *Provider) setRecordsAtomic(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	type hostType struct {
+		host  string
+		rType string
+	}
+
+	groups := make(map[hostType][]libdns.Record)
+	for _, record := range records {
+		rr := record.RR()
+		host := rr.Name
+		if host == "" {
+			host = "@"
+		}
+		key := hostType{host: host, rType: rr.Type}
+		groups[key] = append(groups[key], record)
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	var setRecords []libdns.Record
 
-	if len(records) == 0 {
-		return setRecords, nil
-	}
-
-	data := mythicRecords{}
-	var err = data.FromLibdns(records)
-	if err != nil {
-		return nil, fmt.Errorf("setRecordsAtomic: Error converting libdns records to mythic records: %s", err.Error())
-	}
-
-	payload, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("setRecordsAtomic: Error creating JSON payload: %s", err.Error())
-	}
-
-	// Build query parameters for atomic replacement
-	// We need to select all host/type pairs being set.
-	values := url.Values{}
-	seen := make(map[string]bool)
-
-	for _, rec := range records {
-		rr := rec.RR()
-		// Determine host relative to zone.
-		// SetRecords guarantees Name is relative to zone.
-		host := rr.Name
-
-		key := host + "|" + rr.Type
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-
-		if host == "" || host == "@" {
-			host = "@"
+	for key, groupRecords := range groups {
+		data := mythicRecords{}
+		var err = data.FromLibdns(groupRecords)
+		if err != nil {
+			return nil, fmt.Errorf("setRecordsAtomic: Error converting libdns records to mythic records: %w", err)
 		}
 
-		val := fmt.Sprintf("host=%s&type=%s", host, rr.Type)
-		values.Add("select", val)
+		payload, err := json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("setRecordsAtomic: Error creating JSON payload: %w", err)
+		}
+
+		reqURL := apiURL + "/zones/" + url.PathEscape(zone) + "/records/" + url.PathEscape(key.host) + "/" + url.PathEscape(key.rType)
+		respBody, err := p.doAPIRequest(ctx, "PUT", reqURL, bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("setRecordsAtomic: %w", err)
+		}
+
+		appendResp := mythicRecordUpdate{}
+		err = json.Unmarshal(respBody, &appendResp)
+		if err != nil {
+			return nil, fmt.Errorf("setRecordsAtomic: error parsing response: %w", err)
+		}
+
+		setRecords = append(setRecords, groupRecords...)
 	}
 
-	reqURL := apiURL + "/zones/" + url.PathEscape(zone) + "/records?" + values.Encode()
-
-	respBody, err := p.doAPIRequest(ctx, "PUT", reqURL, bytes.NewReader(payload))
-	if err != nil {
-		return nil, fmt.Errorf("setRecordsAtomic: %w", err)
-	}
-
-	appendResp := mythicRecordUpdate{}
-	err = json.Unmarshal(respBody, &appendResp)
-	if err != nil {
-		return nil, fmt.Errorf("setRecordsAtomic: error parsing response: %w", err)
-	}
-
-	setRecords = append(setRecords, records...)
 	return setRecords, nil
 }
 

--- a/provider.go
+++ b/provider.go
@@ -32,12 +32,12 @@ func (p *Provider) unFQDN(fqdn string) string {
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
 	err := p.login(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("login: provider login failed: %d", err)
+		return nil, fmt.Errorf("login: provider login failed: %w", err)
 	}
 
 	formatedZone, err := publicsuffix.EffectiveTLDPlusOne(p.unFQDN(zone))
 	if err != nil {
-		return nil, fmt.Errorf("Provided zone string malformed %d", err)
+		return nil, fmt.Errorf("Provided zone string malformed: %w", err)
 	}
 
 	p.mutex.Lock()
@@ -52,7 +52,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 
 	err = result.UnmarshalJSON(respBody)
 	if err != nil {
-		return nil, fmt.Errorf("GetRecords: failed to unmarshal response: %d", err)
+		return nil, fmt.Errorf("GetRecords: failed to unmarshal response: %w", err)
 	}
 
 	var records []libdns.Record
@@ -60,7 +60,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	for _, r := range result.Records {
 		record, err := r.GetLibdnsRecord()
 		if err != nil {
-			return nil, fmt.Errorf("GetRecords: failed to parse record %s: %d", r.GetName(), err)
+			return nil, fmt.Errorf("GetRecords: failed to parse record %s: %w", r.GetName(), err)
 		}
 
 		records = append(records, record)
@@ -72,18 +72,18 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	err := p.login(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("login: provider login failed: %d", err)
+		return nil, fmt.Errorf("login: provider login failed: %w", err)
 	}
 
 	formatedZone, err := publicsuffix.EffectiveTLDPlusOne(p.unFQDN(zone))
 	if err != nil {
-		return nil, fmt.Errorf("Provided zone string malformed %d", err)
+		return nil, fmt.Errorf("Provided zone string malformed: %w", err)
 	}
 
 	// Batch add records
 	appendedRecords, err := p.addRecords(ctx, formatedZone, records)
 	if err != nil {
-		return nil, fmt.Errorf("AppendRecords: %d", err)
+		return nil, fmt.Errorf("AppendRecords: %w", err)
 	}
 
 	return appendedRecords, nil
@@ -94,18 +94,18 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	err := p.login(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("login: provider login failed: %d", err)
+		return nil, fmt.Errorf("login: provider login failed: %w", err)
 	}
 
 	formatedZone, err := publicsuffix.EffectiveTLDPlusOne(p.unFQDN(zone))
 	if err != nil {
-		return nil, fmt.Errorf("Provided zone string malformed %d", err)
+		return nil, fmt.Errorf("Provided zone string malformed: %w", err)
 	}
 
 	// Atomic set records
 	setRecord, err := p.setRecordsAtomic(ctx, formatedZone, records)
 	if err != nil {
-		return nil, fmt.Errorf("SetRecords: %d", err)
+		return nil, fmt.Errorf("SetRecords: %w", err)
 	}
 	return setRecord, nil
 }
@@ -114,12 +114,12 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	err := p.login(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("login: provider login failed: %d", err)
+		return nil, fmt.Errorf("login: provider login failed: %w", err)
 	}
 
 	formatedZone, err := publicsuffix.EffectiveTLDPlusOne(p.unFQDN(zone))
 	if err != nil {
-		return nil, fmt.Errorf("Provided zone string malformed %d", err)
+		return nil, fmt.Errorf("Provided zone string malformed: %w", err)
 	}
 
 	var deletedRecords []libdns.Record
@@ -127,7 +127,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	for _, record := range records {
 		deletedRecord, err := p.removeRecord(ctx, formatedZone, record)
 		if err != nil {
-			return deletedRecords, fmt.Errorf("DeleteRecords: %d", err)
+			return deletedRecords, fmt.Errorf("DeleteRecords: %w", err)
 		}
 		deletedRecords = append(deletedRecords, deletedRecord...)
 	}


### PR DESCRIPTION
+ Group records by host/type and use host-specific endpoints (POST/PUT
/zones/{zone}/records/{host}/{type}) instead of zone-level endpoints.
Allows API key use restricted to specific hostnames (e.g. for ACME
_acme-challenge validation) to succeed without returning a 403.

+ Fix error formatting bugs in provider.go by replacing incorrect '%d'
format with '%w' to prevent '%!d(string=...)' log pollution.